### PR TITLE
fix subplot  bug

### DIFF
--- a/summit/goodProfiles.m
+++ b/summit/goodProfiles.m
@@ -132,7 +132,11 @@ for i=1:number_subplots
     
     h = figure;
     if i==1
+      if number_subplots == 1
+        devices_subplot = 1:length(good_r2)
+      else
         devices_subplot = (1:(n*n));
+      end
         
     elseif i*n*n <= plots_display
         devices_subplot=((i*n*n)-(n*n)+1):((i*n*n));


### PR DESCRIPTION
As discussed in #4, this PR fixes the bug reported by @jvlassakis where an index error occurs when fewer than 25 intensity profiles pass the R^2 threshold in `goodProfiles().

Closes #4